### PR TITLE
QOrmEntityListModel::data(): correct conversion of QVector<T*> properties to QVariantList

### DIFF
--- a/examples/orm/navigationdb/main.qml
+++ b/examples/orm/navigationdb/main.qml
@@ -90,6 +90,7 @@ ApplicationWindow {
 
                     Column {
                         id: contentColumn
+                        width: parent.width
                         padding: 6
 
                         Label {
@@ -97,7 +98,14 @@ ApplicationWindow {
                             font.pixelSize: 24
                         }
                         Label {
-                            text: root.forcedUpdate, qsTr("Communities: %2").arg(communityList.length)
+                            text: root.forcedUpdate,
+                                qsTr("Communities: %1").arg(
+                                    communityList.length > 0
+                                        ? communityList.map(community => community.name).join(', ')
+                                        : qsTr("none"))
+
+                            elide: Text.ElideRight
+                            width: parent.width - parent.padding
                         }
                     }
 

--- a/src/orm/qormentitylistmodel.h
+++ b/src/orm/qormentitylistmodel.h
@@ -264,9 +264,9 @@ public:
             {
                 QVariantList list;
 
-                for (const QObject* o : propertyValue.value<QVector<QObject*>>())
+                for (QObject* o : propertyValue.value<QVector<QObject*>>())
                 {
-                    list.push_back(o);
+                    list.push_back(QVariant::fromValue(o));
                 }
 
                 propertyValue = list;

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(domainclasses)
 add_subdirectory(qormentityinstancecache)
+add_subdirectory(qormentitylistmodel)
 add_subdirectory(qormfilterexpression)
 add_subdirectory(qormmetadatacache)
 add_subdirectory(qormsession)

--- a/tests/auto/qormentitylistmodel/CMakeLists.txt
+++ b/tests/auto/qormentitylistmodel/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_executable(tst_ormentitylistmodel
+    tst_qormentitylistmodel.cpp
+
+    domain/province.cpp
+    domain/town.cpp
+
+    domain/province.h
+    domain/town.h
+
+    resource.qrc
+)
+
+target_link_libraries(tst_ormentitylistmodel
+    Qt5::Test
+    qtorm
+)
+
+add_test(NAME tst_ormentitylistmodel COMMAND tst_ormentitylistmodel)

--- a/tests/auto/qormentitylistmodel/domain/province.cpp
+++ b/tests/auto/qormentitylistmodel/domain/province.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019-2021 Dmitriy Purgin <dpurgin@gmail.com>
+ * Copyright (C) 2019 Dmitriy Purgin <dmitriy.purgin@sequality.at>
+ * Copyright (C) 2019 sequality software engineering e.U. <office@sequality.at>
+ *
+ * This file is part of QtOrm library.
+ *
+ * QtOrm is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QtOrm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with QtOrm.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "province.h"
+
+void Province::setId(int id)
+{
+    if (m_id == id)
+        return;
+
+    m_id = id;
+    emit idChanged(m_id);
+}
+
+void Province::setName(QString name)
+{
+    if (m_name == name)
+        return;
+
+    m_name = name;
+    emit nameChanged(m_name);
+}
+
+void Province::setTowns(QVector<Town*> towns)
+{
+    if (m_towns == towns)
+        return;
+
+    m_towns = towns;
+    emit townsChanged(m_towns);
+}

--- a/tests/auto/qormentitylistmodel/domain/province.h
+++ b/tests/auto/qormentitylistmodel/domain/province.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2019-2021 Dmitriy Purgin <dpurgin@gmail.com>
+ * Copyright (C) 2019 Dmitriy Purgin <dmitriy.purgin@sequality.at>
+ * Copyright (C) 2019 sequality software engineering e.U. <office@sequality.at>
+ *
+ * This file is part of QtOrm library.
+ *
+ * QtOrm is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QtOrm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with QtOrm.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QVector>
+
+class Town;
+
+class Province : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(Province)
+
+    Q_PROPERTY(int id READ id WRITE setId NOTIFY idChanged)
+    Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(QVector<Town*> towns READ towns WRITE setTowns NOTIFY townsChanged)
+
+    int m_id;
+    QString m_name;
+    QVector<Town*> m_towns;
+
+public:
+    Q_INVOKABLE Province(QObject* parent = nullptr)
+        : QObject(parent)
+    {
+    }    
+    explicit Province(const QString& name, QObject* parent = nullptr)
+        : QObject{parent}
+        , m_name{name}
+    {
+    }
+    Province(int id, const QString& name, QObject* parent = nullptr)
+        : QObject{parent}
+        , m_id{id}
+        , m_name{name}
+    {
+    }
+
+    virtual ~Province() {}
+    int id() const { return m_id; }
+    QString name() const { return m_name; }
+
+    QVector<Town*> towns() const { return m_towns; }
+
+public slots:
+    void setId(int id);
+    void setName(QString name);
+    void setTowns(QVector<Town*> towns);
+
+signals:
+    void idChanged(int id);
+    void nameChanged(QString name);
+    void townsChanged(QVector<Town*> towns);
+};

--- a/tests/auto/qormentitylistmodel/domain/town.cpp
+++ b/tests/auto/qormentitylistmodel/domain/town.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2019-2021 Dmitriy Purgin <dpurgin@gmail.com>
+ * Copyright (C) 2019 Dmitriy Purgin <dmitriy.purgin@sequality.at>
+ * Copyright (C) 2019 sequality software engineering e.U. <office@sequality.at>
+ *
+ * This file is part of QtOrm library.
+ *
+ * QtOrm is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QtOrm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with QtOrm.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "town.h"
+
+Town::Town(QObject* parent)
+    : QObject(parent)
+{
+}
+
+int Town::id() const
+{
+    return m_id;
+}
+
+QString Town::name() const
+{
+    return m_name;
+}
+
+void Town::setId(int id)
+{
+    if (m_id == id)
+        return;
+
+    m_id = id;
+    emit idChanged(m_id);
+}
+
+void Town::setName(QString name)
+{
+    if (m_name == name)
+        return;
+
+    m_name = name;
+    emit nameChanged(m_name);
+}
+
+Province* Town::province() const
+{
+    return m_province;
+}
+
+void Town::setProvince(Province* province)
+{
+    if (m_province == province)
+        return;
+
+    m_province = province;
+    emit provinceChanged(m_province);
+}

--- a/tests/auto/qormentitylistmodel/domain/town.h
+++ b/tests/auto/qormentitylistmodel/domain/town.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2019-2021 Dmitriy Purgin <dpurgin@gmail.com>
+ * Copyright (C) 2019 Dmitriy Purgin <dmitriy.purgin@sequality.at>
+ * Copyright (C) 2019 sequality software engineering e.U. <office@sequality.at>
+ *
+ * This file is part of QtOrm library.
+ *
+ * QtOrm is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QtOrm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with QtOrm.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+class Province;
+
+class Town : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int id READ id WRITE setId NOTIFY idChanged)
+    Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(Province* province READ province WRITE setProvince NOTIFY provinceChanged)
+
+    int m_id;
+    QString m_name;
+    Province* m_province = nullptr;
+
+public:
+    Q_INVOKABLE explicit Town(QObject* parent = nullptr);
+    Town(const QString& name, Province* province)
+        : m_name{name}
+        , m_province{province}
+    {
+    }
+
+    int id() const;
+    void setId(int id);
+
+    QString name() const;
+    void setName(QString name);
+
+    Province* province() const;
+    void setProvince(Province* province);
+
+signals:
+    void idChanged(int id);
+    void nameChanged(QString name);
+    void provinceChanged(Province* province);
+};

--- a/tests/auto/qormentitylistmodel/qormentitylistmodel.pro
+++ b/tests/auto/qormentitylistmodel/qormentitylistmodel.pro
@@ -1,0 +1,15 @@
+QT = core testlib orm
+
+CONFIG += testcase warn_on silent c++17
+
+TARGET = tst_ormentitylistmodel
+
+SOURCES += tst_ormentitylistmodel.cpp \
+    domain/province.cpp \
+    domain/town.cpp \
+
+HEADERS += \
+    domain/province.h \
+    domain/town.h \
+
+RESOURCES += resource.qrc

--- a/tests/auto/qormentitylistmodel/qormentitylistmodel.qbs
+++ b/tests/auto/qormentitylistmodel/qormentitylistmodel.qbs
@@ -1,0 +1,14 @@
+import qbs
+
+QtApplication {
+    name: "tst_ormentitylistmodel"
+    type: ["application", "autotest"]
+    cpp.cxxLanguageVersion: "c++17"
+    Depends { name: "Qt"; submodules: ["core", "test"] }
+    Depends { name: "QtOrm" }
+    files: [
+        "domain/province.cpp", "domain/province.h",
+        "domain/town.cpp", "domain/town.h",
+        "tst_ormentitylistmodel.cpp",
+        "resource.qrc"]
+}

--- a/tests/auto/qormentitylistmodel/qtorm.json
+++ b/tests/auto/qormentitylistmodel/qtorm.json
@@ -1,0 +1,9 @@
+{
+    "provider": "sqlite",
+    "verbose": true,
+    "sqlite": {
+        "databaseName": ":memory:",
+        "schemaMode": "recreate",
+        "verbose": true
+    }
+}

--- a/tests/auto/qormentitylistmodel/resource.qrc
+++ b/tests/auto/qormentitylistmodel/resource.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file>qtorm.json</file>
+    </qresource>
+</RCC>

--- a/tests/auto/qormentitylistmodel/tst_qormentitylistmodel.cpp
+++ b/tests/auto/qormentitylistmodel/tst_qormentitylistmodel.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2020-2021 Dmitriy Purgin <dpurgin@gmail.com>
+ * Copyright (C) 2019 Dmitriy Purgin <dmitriy.purgin@sequality.at>
+ * Copyright (C) 2019 sequality software engineering e.U. <office@sequality.at>
+ *
+ * This file is part of QtOrm library.
+ *
+ * QtOrm is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * QtOrm is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with QtOrm.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <QtTest>
+
+#include <QOrmEntityListModel>
+#include <QOrmSession>
+#include <QOrmSessionConfiguration>
+
+#include "domain/province.h"
+#include "domain/town.h"
+
+class EntityListModelTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void initTestCase();
+
+    void testQVectorTInData();
+};
+
+void EntityListModelTest::initTestCase()
+{
+    qRegisterOrmEntity<Province, Town>();
+}
+
+// Source: https://github.com/dpurgin/qtorm/issues/15
+void EntityListModelTest::testQVectorTInData()
+{
+    QOrmSession session;
+
+    {
+        Province* upperAustria = new Province(QString::fromUtf8("Oberösterreich"));
+        Province* lowerAustria = new Province(QString::fromUtf8("Niederösterreich"));
+        Province* tirol = new Province(QString::fromUtf8("Tirol"));
+
+        Town* hagenberg = new Town(QString::fromUtf8("Hagenberg"), upperAustria);
+        Town* pregarten = new Town(QString::fromUtf8("Pregarten"), upperAustria);
+        Town* melk = new Town(QString::fromUtf8("Melk"), lowerAustria);
+
+        upperAustria->setTowns({hagenberg, pregarten});
+        lowerAustria->setTowns({melk});
+
+        QVERIFY(session.merge(hagenberg, pregarten, melk, upperAustria, lowerAustria, tirol));
+    }
+
+    QOrmEntityListModel<Province> provinces{session};
+    QCOMPARE(provinces.rowCount(), 3);
+
+    // Roles are generated automatically in the same order as QObject properties
+    // Province::id: UserRole
+    // Province::name: UserRole+1
+    // Province::rowns: UserRole+2
+    QCOMPARE(provinces.data(provinces.index(0), Qt::UserRole).type(), QVariant::Int);
+    QCOMPARE(provinces.data(provinces.index(0), Qt::UserRole).toInt(), 1);
+
+    QCOMPARE(provinces.data(provinces.index(0), Qt::UserRole + 1).type(), QVariant::String);
+    QCOMPARE(provinces.data(provinces.index(0), Qt::UserRole + 1).toString(),
+             QString::fromUtf8("Oberösterreich"));
+
+    QCOMPARE(provinces.data(provinces.index(0), Qt::UserRole + 2).type(), QVariant::List);
+
+    auto val = provinces.data(provinces.index(0), Qt::UserRole + 2).toList();
+    QCOMPARE(val.size(), 2);
+
+    Town* hagenberg = qobject_cast<Town*>(val.first().value<QObject*>());
+    QVERIFY(hagenberg != nullptr);
+    QCOMPARE(hagenberg->id(), 1);
+    QCOMPARE(hagenberg->name(), QString::fromUtf8("Hagenberg"));
+}
+
+QTEST_GUILESS_MAIN(EntityListModelTest)
+
+#include "tst_qormentitylistmodel.moc"


### PR DESCRIPTION
Closes #15 