### PR TITLE
CMake: make library a shared library with a soname and install it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.10)
 
 project(QtOrm LANGUAGES CXX)
 
+set(QTORM_VERSION_MAJOR 1)
+set(QTORM_VERSION_MINOR 0)
+set(QTORM_VERSION_PATCH 1)
+
 # https://stackoverflow.com/questions/25199677/how-to-detect-if-current-scope-has-a-parent-in-cmake
 get_directory_property(hasParent PARENT_DIRECTORY)
 
@@ -21,11 +25,21 @@ if (QTORM_QT_VERSION_HINT STREQUAL "auto")
 
     if (Qt6_FOUND)
         set(QTORM_QT_VERSION_MAJOR 6)
+        set(QTORM_QT_SUFFIX -qt6)
+        set(QTORM_PKGCONFIG_DEPS "Qt6Core")
     else()
         set(QTORM_QT_VERSION_MAJOR 5)
+        set(QTORM_QT_SUFFIX "")
+        set(QTORM_PKGCONFIG_DEPS "Qt5Core")
     endif()
+elseif (QTORM_QT_VERSION_HINT STREQUAL "5")
+    set(QTORM_QT_VERSION_MAJOR 5)
+    set(QTORM_QT_SUFFIX "")
+    set(QTORM_PKGCONFIG_DEPS "Qt5Core")
 else()
-    set(QTORM_QT_VERSION_MAJOR ${QTORM_QT_VERSION_HINT})
+    set(QTORM_QT_VERSION_MAJOR 6)
+    set(QTORM_QT_SUFFIX -qt6)
+    set(QTORM_PKGCONFIG_DEPS "Qt6Core")
 endif()
 
 message("QtOrm Configuration:")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,14 +77,27 @@ set(QTORM_SOURCES
 
 set(BUILD_SHARED_LIBS ${QTORM_BUILD_SHARED_LIBS})
 
-add_library(qtorm
+add_library(qtorm SHARED
     ${QTORM_PUBLIC_HEADERS}
     ${QTORM_PRIVATE_HEADERS}
     ${QTORM_SOURCES}
     ${QTORM_GENERATED_HEADERS}
 )
 
-target_link_libraries(qtorm PUBLIC Qt${QTORM_QT_VERSION_MAJOR}::Core PRIVATE Qt${QTORM_QT_VERSION_MAJOR}::Sql)
+target_link_libraries(
+    qtorm PUBLIC
+    Qt::Core PRIVATE
+    Qt::Sql
+)
+
+set_target_properties(
+      qtorm PROPERTIES
+      VERSION ${QTORM_VERSION_MAJOR}.${QTORM_VERSION_MINOR}.${QTORM_VERSION_PATCH}
+      SOVERSION ${QTORM_VERSION_MAJOR}
+      OUTPUT_NAME qtorm${QTORM_QT_SUFFIX}
+      EXPORT_NAME qtorm${QTORM_QT_SUFFIX}
+      PUBLIC_HEADER "${QTORM_PUBLIC_HEADERS}"
+)
 
 target_compile_definitions(qtorm PRIVATE QT_BUILD_ORM_LIB)
 target_include_directories(qtorm
@@ -98,3 +111,17 @@ target_compile_features(qtorm PUBLIC cxx_std_17)
 if (MSVC)
     target_compile_definitions(qtorm PRIVATE __PRETTY_FUNCTION__=__FUNCTION__)
 endif()
+
+install(
+	TARGETS qtorm
+	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_PREFIX}/include/libqtorm${QTORM_QT_SUFFIX}-${QTORM_VERSION_MAJOR}/QtOrm"
+)
+
+set(LIBQTORM_PC "${CMAKE_CURRENT_BINARY_DIR}/libqtorm${QTORM_QT_SUFFIX}-${QTORM_VERSION_MAJOR}.pc")
+configure_file("libqtorm.pc.in" "${LIBQTORM_PC}" @ONLY)
+
+install(
+    FILES "${LIBQTORM_PC}"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+)

--- a/src/libqtorm.pc.in
+++ b/src/libqtorm.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include
+
+Name: @CMAKE_PROJECT_NAME@
+Description: object-relational mapping for the Qt framework
+Version: @QTORM_VERSION_MAJOR@.@QTORM_VERSION_MINOR@.@QTORM_VERSION_PATCH@
+
+Cflags: -I${includedir}
+Libs: -L${libdir} -lqtorm@QTORM_QT_SUFFIX@
+Requires: @QTORM_PKGCONFIG_DEPS@


### PR DESCRIPTION
The Debian Lomiri team has begun packaging qtorm for Debian.

qtorm currently has no install rules in its CMake files. This pull request adds an install rule for the library. I also made the library a shared library and added a soname to it.

We probably need an install rule for the library headers too, but I am starting with this.